### PR TITLE
Disables linter rule require-atomic-updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,7 +49,7 @@
         "id-blacklist": "error",
         "camelcase": "error",
         "no-underscore-dangle": "error",
-        "require-atomic-updates": "warn",
+        "require-atomic-updates": "off",
         "@typescript-eslint/no-unused-vars": [
             "error",
             {


### PR DESCRIPTION
* Reason: false-positives