### PR TITLE
Execute RenovateBot for automatic dependency updates only Wednesdays

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["every weekday"]
+    "schedule": ["after 6am and before 5pm on Wednesday"]
   },
   "major": {
     "stabilityDays": 3

--- a/.github/workflows/Renovate.yml
+++ b/.github/workflows/Renovate.yml
@@ -3,11 +3,11 @@ on:
   schedule:
     # The "*" character has special semantics in YAML, so this string has to be quoted
     # Execute Mon-Fri every 30 minutes
-    - cron: '0/30 5-19 * * 1-5'
+    - cron: '0/30 5-19 * * 3'
 jobs:
   renovate:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v2.2.0

--- a/renovate.config.js
+++ b/renovate.config.js
@@ -8,7 +8,7 @@ module.exports = {
   onboarding: true,
   onboardingBranch: `${branchName}/configure`,
   platform: 'github',
-  schedule: ["every weekday"],
+  schedule: ["after 6am and before 5pm on Wednesday"],
   regexManagers: [
     {
       datasourceTemplate: 'github-tags',


### PR DESCRIPTION
* Increase timeout for longer running job runs