### PR TITLE
Remove installation of fix declared react, react types versions

### DIFF
--- a/buildScript.js
+++ b/buildScript.js
@@ -2,10 +2,6 @@ const dirTree = require('directory-tree');
 const { execSync } = require('child_process');
 
 const processHubSDKVersion = 'v8.27.0';
-// Put in the react version that is also used in the SDK
-const processHubSDKVersion_React = '16.13.1'
-// Put in the @types/react version that is also used in the SDK
-const processHubSDKVersion_ReactTypes = '16.9.35'
 
 const childProcessStdioOptions = [0, 1, 2];
 const childProcessTimeout = 300000;
@@ -84,13 +80,9 @@ function buildService(directoryPath) {
       timeout: childProcessTimeout
     }
 
-    // Install current processhub-sdk and react version from SDK for child
-    execSync(`npm i --save https://github.com/roXtra/processhub-sdk/releases/download/${processHubSDKVersion}/release.tgz react@${processHubSDKVersion_React}`, childProcessOptions);
-    console.log("Installed current processhub SDK and react for " + directoryPath);
-
-    // Install SDK react types version
-    execSync('npm i -D @types/react@' + processHubSDKVersion_ReactTypes, childProcessOptions);
-    console.log("Installed react types version according to SDK for " + directoryPath);
+    // Install current processhub-sdk for child
+    execSync(`npm i --save https://github.com/roXtra/processhub-sdk/releases/download/${processHubSDKVersion}/release.tgz`, childProcessOptions);
+    console.log("Installed current processhub SDK for " + directoryPath);
 
     // npm install
     execSync('npm install', childProcessOptions);


### PR DESCRIPTION
* Since versions are updated regularly and types are no longer in the resulting service package, locking should no longer be required
* Improve build time
* Be in line with automatic renovate dependency updates