### PR TITLE
Remove Renovate regex manager workaround for updating github actions

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -2,20 +2,14 @@ const branchName = 'auto-dep-update';
 
 module.exports = {
   branchPrefix: `${branchName}/`,
-  enabledManagers: ['github-actions', 'regex', 'npm'],
+  enabledManagers: ['github-actions', 'npm'],
   gitAuthor: 'Dependency Bot <devbot@roxtra.com>',
   logLevel: 'info',
   onboarding: true,
   onboardingBranch: `${branchName}/configure`,
   platform: 'github',
   schedule: ["after 6am and before 5pm on Wednesday"],
-  regexManagers: [
-    {
-      datasourceTemplate: 'github-tags',
-      fileMatch: ['^\\.github/workflows/[^/]+\\.ya?ml$'],
-      matchStrings: ['uses: (?<depName>.*?)@(?<currentValue>.*?)\\s'],
-    },
-  ],
+  regexManagers: [],
   repositories: [
     'roXtra/services',
   ],


### PR DESCRIPTION
* Renovate now supports github-actions tags since https://github.com/renovatebot/renovate/releases/tag/23.55.0