### PR TITLE
Remove explicit babel plugins as they are included in preset-env now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -337,17 +337,6 @@
         "@babel/plugin-syntax-class-static-block": "^7.12.13"
       }
     },
-    "@babel/plugin-proposal-decorators": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.13.15.tgz",
-      "integrity": "sha512-ibAMAqUm97yzi+LPgdr5Nqb9CMkeieGHvwPg1ywSGjZrZHQEGqE01HmOio8kxRpA/+VtOHouIVy2FMpBbtltjA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.13.11",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-decorators": "^7.12.13"
-      }
-    },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz",
@@ -496,15 +485,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.12.13.tgz",
       "integrity": "sha512-ZmKQ0ZXR0nYpHZIIuj9zE7oIqCx2hw9TKi+lIo73NNrMPAZGHfS92/VRV0ZmPj6H2ffBgyFHXvJ5NYsNeEaP2A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-syntax-decorators": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.13.tgz",
-      "integrity": "sha512-Rw6aIXGuqDLr6/LoBBYE57nKOzQpz/aDkKlMqEwH+Vp0MXbG6H/TfRjaY343LKxzAKAMXIHsQ8JzaZKuDZ9MwA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13"

--- a/package.json
+++ b/package.json
@@ -32,10 +32,6 @@
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.13.0",
-    "@babel/plugin-proposal-decorators": "^7.13.15",
-    "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
-    "@babel/plugin-transform-arrow-functions": "^7.13.0",
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",

--- a/server.babel.json
+++ b/server.babel.json
@@ -19,12 +19,6 @@
       }
     ]
   ],
-  "plugins": [
-    "@babel/plugin-transform-arrow-functions",
-    "@babel/proposal-object-rest-spread",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    ["@babel/proposal-class-properties", { "loose": true }]
-  ],
   "env": {
     "debug": {
       "sourceMaps": "inline",


### PR DESCRIPTION
* Remove @babel/plugin-transform-arrow-functions
* Remove @babel/proposal-object-rest-spread
* Remove @babel/plugin-proposal-decorators
* Remove @babel/proposal-class-properties