### PR TITLE
Reduce stability days for renovate bot updates for itself

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -15,6 +15,11 @@ module.exports = {
   ignoreDeps: [],
   packageRules: [
     {
+      matchPackageNames: ["renovatebot/github-action"],
+      // Reduce stability days for renovate bot updates for itself as they update regularly and otherwise, it would never update itself
+      stabilityDays: 1
+    },
+    {
       matchPackageNames: ["node", "@types/node"],
       allowedVersions: "^14.0.0",
     },


### PR DESCRIPTION
* Otherwise, renovate bot does not update itself as they release quite frequently and it will never pass stability days