### PR TITLE
Increase renovate concurrent limits

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -12,6 +12,8 @@ module.exports = {
   regexManagers: [],
   repositories: ["roXtra/services"],
   rebaseWhen: "behind-base-branch",
+  prConcurrentLimit: 6,
+  prHourlyLimit: 6,
   ignoreDeps: [],
   packageRules: [
     {


### PR DESCRIPTION
* Allow more update PRs be opened concurrently as we are hitting the limit frequently at the moment