### PR TITLE
Update server code target to ES2022

### DIFF
--- a/antragsnr/tsconfig.json
+++ b/antragsnr/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/csv/tsconfig.json
+++ b/csv/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/ics/tsconfig.json
+++ b/ics/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/intrafox/tsconfig.json
+++ b/intrafox/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/math/tsconfig.json
+++ b/math/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/mssql/tsconfig.json
+++ b/mssql/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/mysql/tsconfig.json
+++ b/mysql/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/noop/tsconfig.json
+++ b/noop/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/report/tsconfig.json
+++ b/report/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/roxFile/tsconfig.json
+++ b/roxFile/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/sap/tsconfig.json
+++ b/sap/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"],
+    "lib": ["ES2022", "dom"],
     "strictNullChecks": true,
     "skipLibCheck": true
   },

--- a/servicetemplate/tsconfig.json
+++ b/servicetemplate/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/setrole/tsconfig.json
+++ b/setrole/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/setsupervisor/tsconfig.json
+++ b/setsupervisor/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/startinstance/tsconfig.json
+++ b/startinstance/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/systemsettings/tsconfig.json
+++ b/systemsettings/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/triggerwebhook/tsconfig.json
+++ b/triggerwebhook/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "dom"]
   },
   "include": ["./**/*"],
   "exclude": ["./dist/**/*", "./node_modules"]

--- a/tsconfig-webpack.json
+++ b/tsconfig-webpack.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "noImplicitAny": true,
     "jsx": "react-jsx",
     "allowJs": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "lib": ["esnext", "dom"]
+    "lib": ["es2022", "dom"]
   },
   "files": ["main.ts"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = (env) => {
   return {
-    target: "node14",
+    target: "node18",
     mode: "production",
     entry: {
       main: path.resolve(__dirname, env.servicename, "main.ts"),


### PR DESCRIPTION
* According to https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping , ES2022 is the recommended setting for node 18. Based on https://github.com/tsconfig/bases/blob/main/bases/node18.json

Issue: EF-2624