### PR TITLE
Migrate VSCode flag eslint.experimental.useFlatConfig to updated flag eslint.useFlatConfig

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,5 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "typescript.tsdk": "node_modules\\typescript\\lib",
-  "eslint.experimental.useFlatConfig": true
+  "eslint.useFlatConfig": true
 }


### PR DESCRIPTION
* As eslint extension now supports eslint.useFlatConfig. See https://github.com/microsoft/vscode-eslint/issues/1644#issuecomment-2173587025