### PR TITLE
Filter targetField to ProcessHubTextInput fields in oracle service task

### DIFF
--- a/oracle/service.json
+++ b/oracle/service.json
@@ -18,7 +18,7 @@
         { "name": "serviceName", "type": "text" },
         { "name": "useTls", "type": "text" },
         { "name": "query", "type": "text" },
-        { "name": "targetField", "type": "select", "onload": "fields" }
+        { "name": "targetField", "type": "select", "onload": "fields ProcessHubTextInput" }
       ]
     },
     {


### PR DESCRIPTION
Update the oracle service's targetField select to only load fields of type ProcessHubTextInput.

https://rossmanith.atlassian.net/browse/RM-1052